### PR TITLE
fix: Update check to see if `mice` run completed successfully

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Imports:
     coop,
     ICC,
     methods,
-    mice,
+    mice (<= 3.15.0),
     parallel,
     purrr,
     rlecuyer,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: PcAux
 Title: Principle Components Auxiliary Variables
-Version: 0.9.20
+Version: 0.9.21
 Authors@R: c(
     person("Kyle", "Lang", , "k.m.lang@uvt.nl", role = c("aut", "cre")),
     person("Todd", "Little", , "todd.little@ttu.edu", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Imports:
     coop,
     ICC,
     methods,
-    mice (<= 3.15.0),
+    mice,
     parallel,
     purrr,
     rlecuyer,

--- a/R/subroutines.R
+++ b/R/subroutines.R
@@ -393,7 +393,7 @@ doSingleImputation <- function(map, micemethods = micemethods) {
         if(map$verbose > 0) cat("done.\n")
 
         # if(class(map$data) != "try-error") { # mice() didn't crash
-        if(isa(map$data, "data.frame")) {
+        if(!isa(map$data, "try-error")) {
             ## Record any logged events
             map$loggedEvents <- as.data.frame(map$data$loggedEvents)
             ## Save mids


### PR DESCRIPTION
We updated an if statement in a previous release to address new constraints imposed by R 4.2+. However, the if statement was constructed incorrectly which caused some statements to not be evaluated. The if statement is now constructed correctly.